### PR TITLE
Let user specify bounding box

### DIFF
--- a/esdl/cube_config.py
+++ b/esdl/cube_config.py
@@ -223,17 +223,6 @@ class CubeConfig:
 
 
     def _validate(self):
-
-        lat1 = self.lat1
-        lat2 = self.lat0
-        if lat1 >= lat2 or lat1 < -90 or lat1 > 90 or lat2 < -90 or lat2 > 90:
-            raise ValueError('illegal combination of grid_y0, grid_height, spatial_res values')
-
-        lon1 = self.lon0
-        lon2 = self.lon1
-        if lon1 >= lon2 or lon1 < -180 or lon1 > 180 or lon2 < -180 or lon2 > 180:
-            raise ValueError('illegal combination of grid_x0, grid_width, spatial_res values')
-
         if self.chunk_sizes is not None and len(self.chunk_sizes) != 3:
             raise ValueError('chunk_sizes must be a sequence of three integers: <time-size>, <lat-size>, <lon-size>')
 


### PR DESCRIPTION
I factored this into a separate branch because this would change the structure of the cube_config. Currently, when one wants to create a regional cube, one has to specify the parameters `grid_x0` and `grid_y0` which are the offsets of a hypothetical global grid with the specified resolution. This involves some calulculation on the user side when usually the bounding box is known. 

In addition, for very high resolutions (the Sentinel use case by @felixcremer) roundoff-errors get significant and the resulting coordinates were not correct. 

This branch would let the user specify a bounding box as well as the grid_height and grid_width to specifiy the coordinates. Just wanted to get a general opinion by @forman if this is supported or if there was a specific reason for the old behavior. 